### PR TITLE
Correct irritating typo in task name "inventroy"

### DIFF
--- a/tools/aws_lab_setup/roles/email/tasks/main.yml
+++ b/tools/aws_lab_setup/roles/email/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Send email to students with inventroy attached
+- name: Send email to students with inventory attached
   delegate_to: localhost
   sendgrid:
     username: "{{ sendgrid_user | default(omit) }}"


### PR DESCRIPTION
Change from "inventroy" to "inventory".